### PR TITLE
Slack gateway enhancements

### DIFF
--- a/hygroup/agent/base.py
+++ b/hygroup/agent/base.py
@@ -11,6 +11,7 @@ class Message:
     receiver: str | None
     text: str
     handoffs: dict[str, str] | None = None
+    id: str | None = None
 
 
 @dataclass
@@ -24,6 +25,7 @@ class AgentRequest(ABC):
     query: str
     sender: str
     threads: list[Thread] = field(default_factory=list)
+    id: str | None = None
 
 
 @dataclass

--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -225,6 +225,7 @@ class Session:
                 sender=request.sender,
                 receiver=receiver,
                 text=request.query,
+                id=request.id,
             )
             # notify others about this request
             await self.update(message)
@@ -236,6 +237,9 @@ class Session:
                     receiver=request.sender,
                 )
             )
+
+    def contains(self, id: str) -> bool:
+        return any(message.id == id for message in self._messages)
 
     def sync(self, interval: float = 3.0):
         if self._task is None:


### PR DESCRIPTION
- Functional enahncements
  - users may open a thread, not only bots
  - any registered agent can be mentioned in channel, not only app agent

- Reliability enhancements
  - gateway is now idempotent i.e. handles redelivery of messages by Slack
  - gateway is tolerant to downtimes, catches up on non-processed messages