### PR TITLE
Add reactions to Github Gateway

### DIFF
--- a/hygroup/gateway/github/events.py
+++ b/hygroup/gateway/github/events.py
@@ -40,6 +40,7 @@ class PullRequestOpened(GithubEvent):
 
 @dataclass
 class PullRequestCommentCreated(GithubEvent):
+    comment_id: int
     comment: str
 
 
@@ -92,6 +93,7 @@ def map_github_event(event_type: str, payload: dict) -> GithubEvent | None:
                             repository_full_name=payload["repository"]["full_name"],
                             issue_id=payload["issue"]["id"],
                             issue_number=payload["issue"]["number"],
+                            comment_id=payload["comment"]["id"],
                             user_id=payload["comment"]["user"]["id"],
                             username=payload["comment"]["user"]["login"],
                             comment=payload["comment"]["body"],

--- a/hygroup/gateway/github/service.py
+++ b/hygroup/gateway/github/service.py
@@ -38,3 +38,58 @@ class GithubService:
             "created_at": comment.created_at,
             "user": comment.user.login,
         }
+
+    async def add_reaction_to_issue_description(
+        self,
+        repository_name: str,
+        issue_number: int,
+        reaction: str,
+    ) -> dict:
+        return await arun(
+            self._add_reaction_to_issue_blocking,
+            self._github_client,
+            repository_name,
+            issue_number,
+            reaction,
+            None,
+        )
+
+    async def add_reaction_to_issue_comment(
+        self,
+        repository_name: str,
+        issue_number: int,
+        reaction: str,
+        comment_id: int,
+    ) -> dict:
+        return await arun(
+            self._add_reaction_to_issue_blocking,
+            self._github_client,
+            repository_name,
+            issue_number,
+            reaction,
+            comment_id,
+        )
+
+    @staticmethod
+    def _add_reaction_to_issue_blocking(
+        github_client: Github,
+        repository_name: str,
+        issue_number: int,
+        reaction: str,
+        comment_id: int | None = None,
+    ) -> dict:
+        repo = github_client.get_repo(repository_name)
+        issue = repo.get_issue(issue_number)
+
+        if comment_id is not None:
+            comment = issue.get_comment(comment_id)
+            reaction_obj = comment.create_reaction(reaction)
+        else:
+            reaction_obj = issue.create_reaction(reaction)
+
+        return {
+            "id": reaction_obj.id,
+            "content": reaction_obj.content,
+            "created_at": reaction_obj.created_at,
+            "user": reaction_obj.user.login,
+        }


### PR DESCRIPTION
* Add reactions depending on the selector and agent states in the Github Gateway
* Add 'eyes' reaction for selector activation
* Add 'rocket' reaction for agent activation
* Add 'thumbsup' reaction to selector completion without agent activation