### PR TITLE
fix: Add exception handling to SessionAgent.worker() to prevent server hang

### DIFF
--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -64,34 +64,41 @@ class SessionAgent:
                         # -------------------------------------
                         #  TODO: trace query
                         # -------------------------------------
-                        async with self.agent.request_scope(secrets=secrets):
-                            async for elem in self.agent.run(request=request, updates=self._updates, stream=False):
-                                match elem:
-                                    case PermissionRequest():
-                                        # -------------------------------------
-                                        #  TODO: trace permission request
-                                        # -------------------------------------
-                                        await self.session.handle_permission_request(
-                                            request=elem, sender=self.agent.name, receiver=sender
-                                        )
-                                    case FeedbackRequest():
-                                        # -------------------------------------
-                                        #  TODO: trace feedback request
-                                        # -------------------------------------
-                                        await self.session.handle_feedback_request(
-                                            request=elem, sender=self.agent.name, receiver=sender
-                                        )
-                                    case AgentResponse():
-                                        # -------------------------------------
-                                        #  TODO: trace result
-                                        # -------------------------------------
-                                        await self.session.handle_agent_response(
-                                            response=elem, sender=self.agent.name, receiver=sender
-                                        )
+                        try:
+                            async with self.agent.request_scope(secrets=secrets):
+                                async for elem in self.agent.run(request=request, updates=self._updates, stream=False):
+                                    match elem:
+                                        case PermissionRequest():
+                                            # -------------------------------------
+                                            #  TODO: trace permission request
+                                            # -------------------------------------
+                                            await self.session.handle_permission_request(
+                                                request=elem, sender=self.agent.name, receiver=sender
+                                            )
+                                        case FeedbackRequest():
+                                            # -------------------------------------
+                                            #  TODO: trace feedback request
+                                            # -------------------------------------
+                                            await self.session.handle_feedback_request(
+                                                request=elem, sender=self.agent.name, receiver=sender
+                                            )
+                                        case AgentResponse():
+                                            # -------------------------------------
+                                            #  TODO: trace result
+                                            # -------------------------------------
+                                            await self.session.handle_agent_response(
+                                                response=elem, sender=self.agent.name, receiver=sender
+                                            )
 
-                            # agent now has notifications part of
-                            # its history, so we can clear it
-                            self._updates = []
+                                # agent now has notifications part of
+                                # its history, so we can clear it
+                                self._updates = []
+                        except Exception as e:
+                            logger.exception(e)
+                            await self.session.handle_system_response(
+                                response=f"Execution of agent {self.agent.name} failed.",
+                                receiver=sender,
+                            )
 
 
 class Session:


### PR DESCRIPTION
Fixes #41

This PR addresses the server hanging issue when Google Gemini API quota is exceeded by adding proper exception handling to the SessionAgent.worker() method.

### Changes
- Added try-catch block around agent execution in `SessionAgent.worker()`
- Uses `handle_system_response()` with generic error message for user feedback
- Logs exceptions for debugging while keeping server responsive
- Prevents worker task termination that caused server unresponsiveness

### Root Cause
The original issue was that the `SessionAgent.worker()` method lacked exception handling around `self.agent.run()`. When API quota errors occurred, they would propagate up and terminate the worker task, making the server unresponsive to new requests.

### Solution
The fix wraps the agent execution in a try-catch block that:
1. Logs the exception using `logger.exception(e)` for debugging
2. Sends a generic error message to users via `handle_system_response()`
3. Allows the worker to continue processing subsequent requests

Generated with [Claude Code](https://claude.ai/code)