### PR TITLE
Fix server hanging when Google Gemini API quota is exceeded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,6 @@ Additional commands are:
 
 ```bash
 # Code quality checks (linting, formatting, type checking)
-# IMPORTANT: code quality checks only work for files that have been added to git
 invoke code-check
 invoke cc  # alias
 
@@ -25,4 +24,14 @@ invoke cc  # alias
 invoke build-docs  # Build documentation with MkDocs
 invoke serve-docs  # Serve documentation locally at http://localhost:8000
 invoke deploy-docs  # Deploy documentation to GitHub Pages
+```
+
+Important: When running code quality checks on newly generated files, they must be added to git before running the checks:
+
+```bash
+# add newly generated file to git
+git add <new-file>
+
+# run code quality checks on all git-managed files
+invoke cc  # alias
 ```

--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -64,8 +64,8 @@ class SessionAgent:
                         # -------------------------------------
                         #  TODO: trace query
                         # -------------------------------------
-                        try:
-                            async with self.agent.request_scope(secrets=secrets):
+                        async with self.agent.request_scope(secrets=secrets):
+                            try:
                                 async for elem in self.agent.run(request=request, updates=self._updates, stream=False):
                                     match elem:
                                         case PermissionRequest():
@@ -89,16 +89,15 @@ class SessionAgent:
                                             await self.session.handle_agent_response(
                                                 response=elem, sender=self.agent.name, receiver=sender
                                             )
-
                                 # agent now has notifications part of
                                 # its history, so we can clear it
                                 self._updates = []
-                        except Exception as e:
-                            logger.exception(e)
-                            await self.session.handle_system_response(
-                                response=f"Execution of agent '{self.agent.name}' failed.",
-                                receiver=sender,
-                            )
+                            except Exception as e:
+                                logger.exception(e)
+                                await self.session.handle_system_response(
+                                    response=f"Execution of agent '{self.agent.name}' failed.",
+                                    receiver=sender,
+                                )
 
 
 class Session:

--- a/tests/unit/test_session_agent.py
+++ b/tests/unit/test_session_agent.py
@@ -1,10 +1,48 @@
-import logging
+from asyncio import Event
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import pytest_asyncio
 
 from hygroup.agent import Agent, AgentRequest, AgentResponse
 from hygroup.session import Session, SessionAgent
+
+
+class MockSession(Mock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.event = Event()
+        self.handle_system_response_mock = AsyncMock()
+        self.handle_permission_request_mock = AsyncMock()
+        self.handle_feedback_request_mock = AsyncMock()
+        self.handle_agent_response_mock = AsyncMock()
+
+    async def handle_permission_request(self, *args, **kwargs):
+        await self.handle_permission_request_mock(*args, **kwargs)
+        self.event.set()
+
+    async def handle_feedback_request(self, *args, **kwargs):
+        await self.handle_feedback_request_mock(*args, **kwargs)
+        self.event.set()
+
+    async def handle_system_response(self, *args, **kwargs):
+        await self.handle_system_response_mock(*args, **kwargs)
+        self.event.set()
+
+    async def handle_agent_response(self, *args, **kwargs):
+        await self.handle_agent_response_mock(*args, **kwargs)
+        self.event.set()
+
+    async def called(self):
+        await self.event.wait()
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock Session instance with async await capability."""
+    session = MockSession(spec=Session)
+    session.messages = []
+    return session
 
 
 @pytest.fixture
@@ -19,168 +57,171 @@ def mock_agent():
     return agent
 
 
-@pytest.fixture
-def mock_session():
-    """Create a mock Session instance."""
-    session = Mock(spec=Session)
-    session.messages = []
-    session.handle_system_response = AsyncMock()
-    session.handle_permission_request = AsyncMock()
-    session.handle_feedback_request = AsyncMock()
-    session.handle_agent_response = AsyncMock()
-    return session
+@pytest_asyncio.fixture
+async def session_agent(mock_agent, mock_session):
+    session_agent = SessionAgent(mock_agent, mock_session)
+    yield session_agent
+    session_agent._task.cancel()
+    await session_agent._task
 
 
 @pytest.mark.asyncio
-async def test_worker_handles_agent_run_exception(mock_agent, mock_session):
+async def test_worker_handles_agent_run_exception(session_agent, mock_agent, mock_session):
     """Test that worker handles exceptions from agent.run() properly."""
-    # Mock agent.run to raise an exception
     test_exception = Exception("Test exception")
-    mock_agent.run = AsyncMock(side_effect=test_exception)
-    
-    # Create SessionAgent and test request
-    session_agent = SessionAgent(mock_agent, mock_session)
+
+    async def failing_generator(*args, **kwargs):
+        raise test_exception
+        yield  # This won't be reached but makes it a generator
+
+    mock_agent.run = failing_generator
+
     sender = "test_user"
     request = AgentRequest(query="test query", sender=sender)
-    
+
     # Mock the logger to verify exception logging
-    with patch('hygroup.session.logger') as mock_logger:
+    with patch("hygroup.session.logger") as mock_logger:
         # Invoke the agent with the request
         await session_agent.invoke(request, secrets=None)
-        
-        # Give the worker a moment to process the request
-        await session_agent._queue.join()
-        
+
+        # Wait for handle_system_response to be called
+        await mock_session.called()
+
         # Verify exception was logged
         mock_logger.exception.assert_called_once_with(test_exception)
-        
+
         # Verify system response was sent
-        mock_session.handle_system_response.assert_called_once_with(
-            response="Execution of agent 'test_agent' failed.",
-            receiver=sender
+        mock_session.handle_system_response_mock.assert_called_once_with(
+            response="Execution of agent 'test_agent' failed.", receiver=sender
         )
 
 
 @pytest.mark.asyncio
-async def test_worker_handles_agent_run_success(mock_agent, mock_session):
+async def test_worker_handles_agent_run_success(session_agent, mock_agent, mock_session):
     """Test that worker handles successful agent.run() properly."""
     # Mock agent.run to yield a successful response
     test_response = AgentResponse(text="Test response", final=True)
-    mock_agent.run = AsyncMock()
-    mock_agent.run.return_value.__aiter__ = AsyncMock(return_value=iter([test_response]))
-    
-    # Create SessionAgent and test request
-    session_agent = SessionAgent(mock_agent, mock_session)
+
+    async def response_generator(*args, **kwargs):
+        yield test_response
+
+    mock_agent.run = response_generator
+
     sender = "test_user"
     request = AgentRequest(query="test query", sender=sender)
-    
+
     # Mock the logger to verify no exception logging
-    with patch('hygroup.session.logger') as mock_logger:
+    with patch("hygroup.session.logger") as mock_logger:
         # Invoke the agent with the request
         await session_agent.invoke(request, secrets=None)
-        
+
         # Give the worker a moment to process the request
-        await session_agent._queue.join()
-        
+        await mock_session.called()
+
         # Verify no exception was logged
         mock_logger.exception.assert_not_called()
-        
+
         # Verify agent response was handled
-        mock_session.handle_agent_response.assert_called_once_with(
-            response=test_response,
-            sender="test_agent", 
-            receiver=sender
+        mock_session.handle_agent_response_mock.assert_called_once_with(
+            response=test_response, sender="test_agent", receiver=sender
         )
-        
+
         # Verify system response was NOT called
-        mock_session.handle_system_response.assert_not_called()
+        mock_session.handle_system_response_mock.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_worker_continues_after_exception(mock_agent, mock_session):
+async def test_worker_continues_after_exception(session_agent, mock_agent, mock_session):
     """Test that worker continues processing after handling an exception."""
-    # Create SessionAgent
-    session_agent = SessionAgent(mock_agent, mock_session)
     sender = "test_user"
-    
-    # First request - will raise exception
-    first_exception = Exception("First exception")
-    mock_agent.run = AsyncMock(side_effect=first_exception)
+
     first_request = AgentRequest(query="first query", sender=sender)
-    
+    first_exception = Exception("First exception")
+
+    async def failing_generator(*args, **kwargs):
+        raise first_exception
+        yield  # This won't be reached but makes it a generator
+
     # Second request - will succeed
     second_response = AgentResponse(text="Second response", final=True)
-    
-    with patch('hygroup.session.logger') as mock_logger:
+
+    async def response_generator(*args, **kwargs):
+        yield second_response
+
+    with patch("hygroup.session.logger") as mock_logger:
+        mock_agent.run = failing_generator
+
         # Invoke first request (will fail)
         await session_agent.invoke(first_request, secrets=None)
-        
+
         # Give the worker a moment to process the first request
-        await session_agent._queue.join()
-        
+        await mock_session.called()
+        mock_session.event.clear()
+
         # Verify first exception was handled
         mock_logger.exception.assert_called_once_with(first_exception)
-        assert mock_session.handle_system_response.call_count == 1
-        
-        # Now mock agent.run to succeed for second request
-        mock_agent.run = AsyncMock()
-        mock_agent.run.return_value.__aiter__ = AsyncMock(return_value=iter([second_response]))
-        
-        # Reset mocks for second request verification
+        assert mock_session.handle_system_response_mock.call_count == 1
+
+        # reset for second request
         mock_logger.reset_mock()
-        mock_session.reset_mock()
-        
+        mock_session.handle_system_response_mock.reset_mock()
+
+        # Now mock agent.run to succeed for second request
+        mock_agent.run = response_generator
+
         # Invoke second request (will succeed)
         second_request = AgentRequest(query="second query", sender=sender)
         await session_agent.invoke(second_request, secrets=None)
-        
+
         # Give the worker a moment to process the second request
-        await session_agent._queue.join()
-        
+        await mock_session.called()
+
         # Verify second request was processed successfully
         mock_logger.exception.assert_not_called()
-        mock_session.handle_agent_response.assert_called_once_with(
-            response=second_response,
-            sender="test_agent",
-            receiver=sender
+        mock_session.handle_agent_response_mock.assert_called_once_with(
+            response=second_response, sender="test_agent", receiver=sender
         )
-        mock_session.handle_system_response.assert_not_called()
+        mock_session.handle_system_response_mock.assert_not_called()
 
 
 @pytest.mark.parametrize(
     "exception_type, exception_message",
     [
         (ValueError, "Invalid value"),
-        (RuntimeError, "Runtime error occurred"), 
+        (RuntimeError, "Runtime error occurred"),
         (ConnectionError, "Connection failed"),
         (Exception, "Generic exception"),
-    ]
+    ],
 )
 @pytest.mark.asyncio
-async def test_worker_handles_different_exception_types(mock_agent, mock_session, exception_type, exception_message):
+async def test_worker_handles_different_exception_types(
+    session_agent, mock_agent, mock_session, exception_type, exception_message
+):
     """Test that worker handles various exception types consistently."""
     # Mock agent.run to raise the specified exception
     test_exception = exception_type(exception_message)
-    mock_agent.run = AsyncMock(side_effect=test_exception)
-    
-    # Create SessionAgent and test request
-    session_agent = SessionAgent(mock_agent, mock_session)
+
+    async def failing_generator(*args, **kwargs):
+        raise test_exception
+        yield  # This won't be reached but makes it a generator
+
+    mock_agent.run = failing_generator
+
     sender = "test_user"
     request = AgentRequest(query="test query", sender=sender)
-    
+
     # Mock the logger to verify exception logging
-    with patch('hygroup.session.logger') as mock_logger:
+    with patch("hygroup.session.logger") as mock_logger:
         # Invoke the agent with the request
         await session_agent.invoke(request, secrets=None)
-        
+
         # Give the worker a moment to process the request
-        await session_agent._queue.join()
-        
+        await mock_session.called()
+
         # Verify exception was logged
         mock_logger.exception.assert_called_once_with(test_exception)
-        
+
         # Verify system response was sent with generic message regardless of exception type
-        mock_session.handle_system_response.assert_called_once_with(
-            response="Execution of agent 'test_agent' failed.",
-            receiver=sender
+        mock_session.handle_system_response_mock.assert_called_once_with(
+            response="Execution of agent 'test_agent' failed.", receiver=sender
         )


### PR DESCRIPTION
Add exception handling in SessionAgent.worker() to prevent worker task termination when agent execution fails.

The fix:
- Wraps agent.run() in try-catch block
- Logs full exception details for debugging
- Sends generic error message to user: "Execution of agent '{name}' failed."
- Allows server to continue processing subsequent requests

Fixes #41

Generated with [Claude Code](https://claude.ai/code)