### PR TITLE
Fix PyPI video thumbnail by using absolute GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <div align="left">
   <a href="https://www.youtube.com/watch?v=OxOmRsNin4o">
-    <img src="docs/images/overview/video.jpg" alt="Watch the video" style="width: 50%;">
+    <img src="https://raw.githubusercontent.com/gradion-ai/hybrid-groups/main/docs/images/overview/video.jpg" alt="Watch the video" style="width: 50%;">
   </a>
 </div>
 


### PR DESCRIPTION
Fixes #47

This PR resolves the issue where the video thumbnail wasn't displaying on the PyPI package page.

## Changes
- Replace relative path `docs/images/overview/video.jpg` with absolute GitHub raw URL
- This allows the video thumbnail to display correctly on PyPI package page
- PyPI cannot access relative paths to files not included in the package distribution

Generated with [Claude Code](https://claude.ai/code)