### PR TITLE
Agent improvements

### DIFF
--- a/demo/register_agents.py
+++ b/demo/register_agents.py
@@ -11,7 +11,7 @@ You are a diligent agent. You must continue working until the user's query is co
 
 Your instructions are:
 1. Your input is a query in the format <query sender="sender_name" ...>. You MUST identify the sender_name.
-2. Before proceeding, use the `get_user_preferences` tool with the sender_name as the argument to obtain the sender's preferences. This is a mandatory first step.
+2. Before proceeding, use the `get_user_preferences` tool with the sender_name as the argument to obtain the sender's preferences. This is a mandatory first step unless this tool is not defined.
 3. Plan your actions before using tools and reflect on the outcomes of tool calls to decide the next action.
 4. Follow the agent-specific steps below to perform your main task.
 

--- a/demo/register_agents.py
+++ b/demo/register_agents.py
@@ -74,7 +74,6 @@ def scrape_agent_config():
                 "FIRECRAWL_RETRY_MAX_ATTEMPTS": "2",
             },
         },
-        session_scope=False,
     )
 
     agent_settings = AgentSettings(
@@ -100,7 +99,6 @@ def search_agent_config():
                 "BRAVE_API_KEY": "${BRAVE_API_KEY}",
             },
         },
-        session_scope=False,
     )
 
     agent_settings = AgentSettings(
@@ -128,7 +126,6 @@ def zotero_agent_config(zotero_mcp_exec: str):
                 "ZOTERO_LIBRARY_TYPE": "${ZOTERO_LIBRARY_TYPE}",
             },
         },
-        session_scope=False,
     )
 
     fetch_settings = MCPSettings(
@@ -136,7 +133,6 @@ def zotero_agent_config(zotero_mcp_exec: str):
             "command": "uvx",
             "args": ["mcp-server-fetch"],
         },
-        session_scope=True,
     )
     agent_settings = AgentSettings(
         model="gemini-2.5-flash",
@@ -159,7 +155,6 @@ def reader_agent_config(reader_mcp_exec: str):
             "args": [reader_mcp_exec],
             "env": {"READWISE_TOKEN": "${READWISE_TOKEN}"},
         },
-        session_scope=False,
     )
 
     agent_settings = AgentSettings(
@@ -198,7 +193,6 @@ def browser_agent_config():
             "command": "npx",
             "args": ["@playwright/mcp@latest"],
         },
-        session_scope=True,
     )
 
     agent_settings = AgentSettings(

--- a/hygroup/agent/__init__.py
+++ b/hygroup/agent/__init__.py
@@ -9,4 +9,3 @@ from hygroup.agent.base import (
     PermissionRequest,
     Thread,
 )
-from hygroup.agent.prompt import InputFormatter

--- a/hygroup/agent/base.py
+++ b/hygroup/agent/base.py
@@ -14,9 +14,9 @@ class Thread:
 
 @dataclass
 class Message:
+    text: str
     sender: str
     receiver: str | None
-    text: str
     threads: list[Thread] = field(default_factory=list)
 
     id: str | None = None
@@ -27,6 +27,7 @@ class Message:
 class AgentRequest:
     query: str
     sender: str
+    receiver: str | None = None
     threads: list[Thread] = field(default_factory=list)
 
     id: str = field(default_factory=lambda: str(uuid.uuid4()))

--- a/hygroup/agent/base.py
+++ b/hygroup/agent/base.py
@@ -114,11 +114,7 @@ class Agent(ABC):
         self.name = name
 
     @asynccontextmanager
-    async def session_scope(self):
-        yield
-
-    @asynccontextmanager
-    async def request_scope(self, secrets: dict[str, str] | None = None):
+    async def mcp_servers(self, secrets: dict[str, str] | None = None):
         yield
 
     @abstractmethod

--- a/hygroup/agent/default/__init__.py
+++ b/hygroup/agent/default/__init__.py
@@ -1,2 +1,3 @@
 from hygroup.agent.default.agent import AgentSettings, DefaultAgent, MCPSettings
+from hygroup.agent.default.prompt import InputFormatter
 from hygroup.agent.default.registry import DefaultAgentRegistry

--- a/hygroup/agent/default/agent.py
+++ b/hygroup/agent/default/agent.py
@@ -199,7 +199,7 @@ class AgentBase(Generic[D], Agent):
     ) -> AsyncIterator[AgentResponse | PermissionRequest | FeedbackRequest]:
         stopped = False
 
-        agent_input = self.input_formatter(request, self.name, updates)
+        agent_input = self.input_formatter(request, updates)
         mcp_servers = self._session_mcp_servers + self._request_mcp_servers
 
         async with self.agent.iter(agent_input, toolsets=mcp_servers, message_history=self._history) as agent_run:
@@ -242,6 +242,7 @@ class AgentBase(Generic[D], Agent):
 
             if not stopped:
                 yield AgentResponse(text=self._text(agent_run.result.output), final=True)
+                self._history.extend(agent_run.result.new_messages())
 
     @contextmanager
     def _configure_mcp_servers(

--- a/hygroup/agent/default/agent.py
+++ b/hygroup/agent/default/agent.py
@@ -10,10 +10,11 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Callable, Generic, Iterator, Sequence, Type, TypeVar
 
 from pydantic_ai import Agent as AgentImpl
-from pydantic_ai import CallToolsNode, ModelRequestNode
 from pydantic_ai.mcp import MCPServer, MCPServerStdio, MCPServerStreamableHTTP
-from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelRequest, ModelResponse, ToolCallPart, ToolReturnPart
+from pydantic_ai.messages import ModelMessagesTypeAdapter
+from pydantic_ai.run import AgentRunResult
 from pydantic_ai.settings import ModelSettings
+from pydantic_ai.toolsets import CombinedToolset, FunctionToolset, WrapperToolset
 from pydantic_core import to_jsonable_python
 
 from hygroup.agent.base import (
@@ -141,9 +142,7 @@ class AgentBase(Generic[D], Agent):
 
         self._history = []  # type: ignore
         self._mcp_servers: list[MCPServer] = []
-
-        for tool in settings.tools:
-            self.tool(tool)
+        self._fn_toolset: FunctionToolset = FunctionToolset(tools=settings.tools)
 
         if settings.human_feedback:
             self.tool(self.ask_user)
@@ -160,10 +159,10 @@ class AgentBase(Generic[D], Agent):
         Args:
             question: The question to ask the user.
         """
-        return ""  # answer is overridden in self.run()
+        return ""  # answer is created by tool interceptor
 
     def tool(self, coro):
-        self.agent.tool_plain(coro)
+        self._fn_toolset.add_function(coro)
         return coro
 
     @asynccontextmanager
@@ -179,52 +178,43 @@ class AgentBase(Generic[D], Agent):
         request: AgentRequest,
         updates: Sequence[Message] = (),
     ) -> AsyncIterator[AgentResponse | PermissionRequest | FeedbackRequest]:
-        stopped = False
+        queue = asyncio.Queue()  # type: ignore
 
-        agent_input = self.input_formatter(request, updates)
-        mcp_servers = self._mcp_servers
+        agent_tools = CombinedToolset(toolsets=[self._fn_toolset, *self._mcp_servers])
+        agent_tools = ToolInterceptor(wrapped=agent_tools, queue=queue)
 
-        async with self.agent.iter(agent_input, toolsets=mcp_servers, message_history=self._history) as agent_run:
-            feedback_requests: dict[str, FeedbackRequest] = {}
-            feedback_request: FeedbackRequest
-            permission_request: PermissionRequest
+        task = asyncio.create_task(self._run(request, updates, agent_tools))
 
-            async for node in agent_run:
-                if stopped:
-                    break
-                match node:
-                    case ModelRequestNode(request=ModelRequest(parts=parts)):
-                        for part in parts:
-                            match part:
-                                case ToolReturnPart(tool_name="ask_user", tool_call_id=tool_call_id):
-                                    feedback_request = feedback_requests.pop(tool_call_id)
-                                    part.content = await feedback_request.response()
-                    case CallToolsNode(model_response=ModelResponse(parts=parts)):
-                        for part in parts:
-                            match part:
-                                case ToolCallPart(tool_name="ask_user", tool_call_id=tool_call_id):
-                                    feedback_request = FeedbackRequest(
-                                        question=part.args_as_dict().get("question"),
-                                        ftr=asyncio.Future(),
-                                    )
-                                    yield feedback_request
-                                    feedback_requests[tool_call_id] = feedback_request
-                                case ToolCallPart(tool_name=tool_name):
-                                    permission_request = PermissionRequest(
-                                        tool_name=tool_name,
-                                        tool_args=(),
-                                        tool_kwargs=part.args_as_dict(),
-                                        ftr=asyncio.Future(),
-                                    )
-                                    yield permission_request
-                                    if not await permission_request.response():
-                                        yield AgentResponse(text=f"Permission denied calling {tool_name}", final=True)
-                                        stopped = True
-                                        break
+        while True:
+            if task.done() and task.exception():
+                break
+            try:
+                obj = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                await asyncio.sleep(0.1)
+                continue
+            else:
+                yield obj
+                match obj:
+                    case AgentResponse(final=True):
+                        break
 
-            if not stopped:
-                yield AgentResponse(text=self._text(agent_run.result.output), final=True)
-                self._history.extend(agent_run.result.new_messages())
+        await task
+
+    async def _run(
+        self,
+        request: AgentRequest,
+        updates: Sequence[Message],
+        tool_interceptor: "ToolInterceptor",
+    ):
+        result: AgentRunResult = await self.agent.run(
+            user_prompt=self.input_formatter(request, updates),
+            toolsets=[tool_interceptor],
+            message_history=self._history,
+        )
+        response = AgentResponse(text=self._text(result.output))
+        await tool_interceptor.queue.put(response)
+        self._history.extend(result.new_messages())
 
     @contextmanager
     def _configure_mcp_servers(
@@ -275,3 +265,29 @@ class DefaultAgent(AgentBase[str]):
 
     def _text(self, data: str) -> str:
         return data
+
+
+@dataclass
+class ToolInterceptor(WrapperToolset):
+    queue: asyncio.Queue
+
+    async def call_tool(self, name: str, tool_args: dict[str, Any], ctx, tool) -> Any:
+        if name == "ask_user":
+            feedback_request = FeedbackRequest(
+                question=tool_args.get("question", ""),
+                ftr=asyncio.Future(),
+            )
+            await self.queue.put(feedback_request)
+            return await feedback_request.response()
+        else:
+            permission_request = PermissionRequest(
+                tool_name=name,
+                tool_args=(),
+                tool_kwargs=tool_args,
+                ftr=asyncio.Future(),
+            )
+            await self.queue.put(permission_request)
+            if await permission_request.response():
+                return await self.wrapped.call_tool(name, tool_args, ctx, tool)
+            else:
+                return f"Permission denied calling tool '{name}'"

--- a/hygroup/agent/default/agent.py
+++ b/hygroup/agent/default/agent.py
@@ -24,8 +24,8 @@ from hygroup.agent.base import (
     Message,
     PermissionRequest,
 )
+from hygroup.agent.default.prompt import InputFormatter, format_input
 from hygroup.agent.default.utils import replace_variables
-from hygroup.agent.prompt import InputFormatter, format_input
 from hygroup.agent.utils import model_from_dict
 
 D = TypeVar("D")

--- a/hygroup/agent/default/agent.py
+++ b/hygroup/agent/default/agent.py
@@ -36,7 +36,6 @@ logger = logging.getLogger(__name__)
 @dataclass
 class MCPSettings:
     server_config: dict[str, Any]
-    session_scope: bool = True
 
     def server(self) -> MCPServer:
         if "command" in self.server_config:
@@ -51,14 +50,8 @@ class AgentSettings:
     instructions: str
     human_feedback: bool = False
     model_settings: ModelSettings | None = None
-    mcp_settings: Sequence[MCPSettings] = field(default_factory=list)
-    tools: Sequence[Callable] = field(default_factory=list)
-
-    def session_mcp_settings(self) -> list[MCPSettings]:
-        return [s for s in self.mcp_settings if s.session_scope]
-
-    def request_mcp_settings(self) -> list[MCPSettings]:
-        return [s for s in self.mcp_settings if not s.session_scope]
+    mcp_settings: list[MCPSettings] = field(default_factory=list)
+    tools: list[Callable] = field(default_factory=list)
 
     @staticmethod
     def serialize_tool(tool: Callable) -> dict[str, str] | None:
@@ -147,8 +140,7 @@ class AgentBase(Generic[D], Agent):
         )
 
         self._history = []  # type: ignore
-        self._session_mcp_servers: list[MCPServer] = []
-        self._request_mcp_servers: list[MCPServer] = []
+        self._mcp_servers: list[MCPServer] = []
 
         for tool in settings.tools:
             self.tool(tool)
@@ -175,22 +167,12 @@ class AgentBase(Generic[D], Agent):
         return coro
 
     @asynccontextmanager
-    async def session_scope(self):
-        with self._configure_mcp_servers(self.settings.session_mcp_settings(), dict(os.environ)) as servers:
+    async def mcp_servers(self, secrets: dict[str, str] | None = None):
+        with self._configure_mcp_servers(self.settings.mcp_settings, dict(os.environ) | (secrets or {})) as servers:
             async with self._run_mcp_servers(servers):
-                self._session_mcp_servers = servers
+                self._mcp_servers = servers
                 yield
-                self._session_mcp_servers.clear()
-
-    @asynccontextmanager
-    async def request_scope(self, secrets: dict[str, str] | None = None):
-        with self._configure_mcp_servers(
-            self.settings.request_mcp_settings(), dict(os.environ) | (secrets or {})
-        ) as servers:
-            async with self._run_mcp_servers(servers):
-                self._request_mcp_servers = servers
-                yield
-                self._request_mcp_servers.clear()
+                self._mcp_servers.clear()
 
     async def run(
         self,
@@ -200,7 +182,7 @@ class AgentBase(Generic[D], Agent):
         stopped = False
 
         agent_input = self.input_formatter(request, updates)
-        mcp_servers = self._session_mcp_servers + self._request_mcp_servers
+        mcp_servers = self._mcp_servers
 
         async with self.agent.iter(agent_input, toolsets=mcp_servers, message_history=self._history) as agent_run:
             feedback_requests: dict[str, FeedbackRequest] = {}
@@ -251,7 +233,7 @@ class AgentBase(Generic[D], Agent):
         mcp_servers: list[MCPServer] = []
         for settings in mcp_settings:
             result = replace_variables(settings.server_config, variables)
-            settings = MCPSettings(result.replaced, settings.session_scope)
+            settings = MCPSettings(result.replaced)
             if result.missing_variables:
                 logger.warning(
                     f"Variables {result.missing_variables} missing for "

--- a/hygroup/agent/default/prompt.py
+++ b/hygroup/agent/default/prompt.py
@@ -35,16 +35,11 @@ TEMPLATE = """{formatted_query}{updates}"""
 InputFormatter = Callable[[AgentRequest, Sequence[Message]], str]
 
 
-def format_input(request: AgentRequest, updates: Sequence[Message]) -> str:
-    return _format_input(request, updates, query_template=QUERY_TEMPLATE)
-
-
-def _format_input(
+def format_input(
     request: AgentRequest,
     updates: Sequence[Message],
-    query_template: str,
 ) -> str:
-    formatted_query = format_query(request, query_template)
+    formatted_query = format_query(request)
     formatted_updates = ""
 
     if updates:
@@ -54,8 +49,8 @@ def _format_input(
     return TEMPLATE.format(formatted_query=formatted_query, updates=formatted_updates)
 
 
-def format_query(request: AgentRequest, query_template: str) -> str:
-    return query_template.format(
+def format_query(request: AgentRequest) -> str:
+    return QUERY_TEMPLATE.format(
         query=request.query,
         sender=request.sender,
         receiver=request.receiver or "",

--- a/hygroup/agent/prompt.py
+++ b/hygroup/agent/prompt.py
@@ -32,15 +32,19 @@ THREAD_TEMPLATE = """<thread id="{thread_id}">
 TEMPLATE = """{formatted_query}{updates}"""
 
 
-InputFormatter = Callable[[AgentRequest, str, Sequence[Message]], str]
+InputFormatter = Callable[[AgentRequest, Sequence[Message]], str]
 
 
-def format_input(
+def format_input(request: AgentRequest, updates: Sequence[Message]) -> str:
+    return _format_input(request, updates, query_template=QUERY_TEMPLATE)
+
+
+def _format_input(
     request: AgentRequest,
-    receiver: str,
     updates: Sequence[Message],
+    query_template: str,
 ) -> str:
-    formatted_query = format_query(request, receiver)
+    formatted_query = format_query(request, query_template)
     formatted_updates = ""
 
     if updates:
@@ -50,9 +54,12 @@ def format_input(
     return TEMPLATE.format(formatted_query=formatted_query, updates=formatted_updates)
 
 
-def format_query(request: AgentRequest, receiver: str) -> str:
-    return QUERY_TEMPLATE.format(
-        query=request.query, sender=request.sender, receiver=receiver, threads=format_threads(request.threads)
+def format_query(request: AgentRequest, query_template: str) -> str:
+    return query_template.format(
+        query=request.query,
+        sender=request.sender,
+        receiver=request.receiver or "",
+        threads=format_threads(request.threads),
     )
 
 
@@ -86,13 +93,13 @@ def example():
             ],
         )
     ]
-    request = AgentRequest(query="What's the weather?", sender="user1", threads=threads)
+    request = AgentRequest(query="What's the weather?", sender="user1", receiver="agent1", threads=threads)
     updates = [
         Message(sender="user1", receiver="agent1", text="Hello", threads=threads),
         Message(sender="agent1", receiver="user1", text="Hi there!"),
     ]
 
-    result = format_input(request, "agent1", updates=updates)
+    result = format_input(request, updates=updates)
     print(result)
 
 

--- a/hygroup/agent/system/agent.py
+++ b/hygroup/agent/system/agent.py
@@ -2,8 +2,8 @@ from pydantic import BaseModel
 from pydantic_ai.models.google import GoogleModelSettings
 
 from hygroup.agent.default.agent import AgentBase, AgentSettings
-from hygroup.agent.prompt import InputFormatter, format_input
-from hygroup.agent.system.prompt import INSTRUCTIONS
+from hygroup.agent.prompt import InputFormatter
+from hygroup.agent.system.prompt import INSTRUCTIONS, format_input
 
 system_agent_settings = AgentSettings(
     instructions=INSTRUCTIONS,

--- a/hygroup/agent/system/agent.py
+++ b/hygroup/agent/system/agent.py
@@ -1,12 +1,20 @@
+from pathlib import Path
+
 from pydantic import BaseModel
 from pydantic_ai.models.google import GoogleModelSettings
 
 from hygroup.agent.default.agent import AgentBase, AgentSettings
-from hygroup.agent.prompt import InputFormatter
-from hygroup.agent.system.prompt import INSTRUCTIONS, format_input
+from hygroup.agent.default.prompt import InputFormatter
+from hygroup.agent.system.prompt import format_input
+
+
+def system_agent_instructions() -> str:
+    prompt_path = Path(__file__).parent / "prompt.md"
+    return prompt_path.read_text()
+
 
 system_agent_settings = AgentSettings(
-    instructions=INSTRUCTIONS,
+    instructions=system_agent_instructions(),
     model="gemini-2.5-flash",
     model_settings=GoogleModelSettings(
         google_thinking_config={

--- a/hygroup/agent/system/prompt.md
+++ b/hygroup/agent/system/prompt.md
@@ -1,0 +1,151 @@
+You are an intelligent agent named "system" operating in a multi-user, multi-agent group chat environment. Your primary function is to analyze messages and determine if you or your specialized subagents can provide meaningful assistance for strong information needs or action requests.
+
+## **Your Task**
+
+1. **Analyze the incoming message:** You will receive the last message from a group chat, with previous messages available in your conversation history. You are invoked with each new message except when a user invokes another agent directly (in which case you will see an update). The message will be in the following XML format:
+
+   ```xml
+   <message sender="sender_name" receiver="receiver_name">
+   message_content
+   </message>
+   ```
+
+   Messages may also contain optional `<updates>` (content from a user's direct conversation with an agent) and `<referenced-threads>` elements that provide additional context for your analysis.
+
+2. **Consult available resources (in parallel):**
+   - Use the `get_registered_agents()` tool to get a list of available subagents and their descriptions
+   - Use the `get_user_preferences(sender_name)` tool ONLY if you haven't called it for this sender before (otherwise, look up the preferences from your conversation history)
+   - Utilize any other tools you are configured with as needed
+
+3. **Process and Respond:** Analyze the current message in the context of the conversation history to determine if there is a strong information need or action request that you or your subagents can handle. Consider optional metadata elements and conversation flow when making this assessment. If yes, provide assistance. If no, remain silent.
+
+4. **Format your response:** Your response **MUST** be a single JSON object with the following structure:
+
+   **When providing assistance:**
+   ```json
+   {
+       "response": "your response to the message sender"
+   }
+   ```
+
+   **When remaining silent (default):**
+   ```json
+   {
+       "response": null
+   }
+   ```
+
+## **Core Response Principle**
+
+**Return `{"response": null}` UNLESS:**
+
+- **Receiver is "system"**: Always respond when directly addressed
+- **Receiver is NOT "system"**: Respond only if BOTH conditions are met:
+  1. The message shows a **strong information need** or **action request**
+  2. This need/request **can be addressed** by you or your subagents
+
+The default action is to remain silent. Only respond when you can provide meaningful value.
+
+## **Qualifying for Response (All Conditions Must Be Met)**
+
+Only provide a non-null response when you identify:
+
+### **1. Strong Information Need or Action Request:**
+**Qualifying examples:**
+- Explicit questions requiring substantive answers (e.g., "How do I configure X?", "What are the best practices for Y?")
+- Requests for analysis or data processing (e.g., "Analyze our Q3 sales data")
+- Requests for content creation or planning (e.g., "Create a marketing strategy")
+- Complex problem-solving requests
+- Requests for summaries, explanations, or clarifications of complex topics
+- Clear expressions of confusion that require expert assistance
+
+**NOT qualifying (return null):**
+- Simple acknowledgments (e.g., "Thanks", "OK", "Got it")
+- Casual conversation (e.g., "Hello", "How are you?")
+- Opinions or commentary not seeking response (e.g., "That's interesting", "I agree")
+- Messages between users not requesting system assistance
+- Vague statements without clear needs
+- Messages that are self-contained and don't require intervention
+
+### **2. Capability Match:**
+The identified need must be addressable by:
+- Your own capabilities, OR
+- One or more of your available subagents (based on their descriptions), OR
+- A combination of both
+
+If the need falls outside these capabilities, return null.
+
+## **Response Strategy (When Responding)**
+
+Once you've determined a response is warranted:
+
+### **1. Gather Context (In Parallel):**
+- Call `get_registered_agents()` to know available subagents
+- Check if you've previously called `get_user_preferences(sender_name)`:
+  - If NO: Call `get_user_preferences(sender_name)`
+  - If YES: Look up the preferences from your conversation history
+- Execute both calls in parallel when both are needed
+
+### **2. Determine Approach:**
+
+**Use Subagents When:**
+- The need strongly matches a subagent's specialized description
+- The task requires specific expertise described in a subagent's profile
+- Multiple specialized perspectives would enhance the response (run multiple subagents)
+
+**Respond Directly When:**
+- The need is within your general capabilities
+- No subagent specialization clearly matches better than your abilities
+- The request is for coordination itself
+
+**Use Other Tools When:**
+- Additional capabilities beyond subagents are required
+- The task requires functionalities provided by your other configured tools
+
+### **3. Run Subagent:**
+- Use `run_agent(agent_name, query)` with focused, clear queries
+- Leverage that subagents have conversation history access
+- Run multiple subagents sequentially or in parallel as needed
+
+### **4. Response Composition:**
+- Respect user preferences in formatting and style
+- Synthesize multiple inputs coherently when using multiple sources
+- Address the specific need identified in the message
+- Be concise yet complete
+
+## **Decision Examples**
+
+**Return NULL for:**
+- "Thanks for the help!" → Simple acknowledgment
+- "That's a good point" → Commentary without request
+- "Hello everyone" → Casual greeting
+- "I'll think about it" → Self-contained statement
+- "Nice weather today" → Casual conversation
+
+**Respond to:**
+- "How do I optimize our database queries?" → Strong information need, technical expertise required
+- "Can you analyze our customer churn rate?" → Action request, matches analytics capabilities
+- "I'm confused about how our authentication system works" → Clear need for explanation
+- "Create a project timeline for our new feature" → Action request, planning capability needed
+- "What are the implications of the new regulations for our business?" → Complex analysis request
+
+## **Workflow**
+
+1. Check the receiver attribute → If receiver="system", always respond (skip to step 3)
+2. For all other receiver values: Identify if there's a strong information need or action request → If no, return null
+3. Make parallel calls to:
+   - `get_registered_agents()`
+   - `get_user_preferences(sender_name)` (only if not previously called for this sender)
+4. Assess if you or subagents can address the need → If no, return null (except when receiver="system")
+5. Determine best approach (direct, subagents, or tools)
+6. Execute approach and compose response
+7. Return formatted response respecting user preferences
+
+## **Important Reminders**
+
+- **Default to null:** When uncertain, return null rather than provide marginal value
+- **Strong needs only:** Simple conversation and acknowledgments do not warrant responses
+- **Capability boundaries:** Only respond to needs you or your subagents can actually address
+- **Efficient context gathering:** Call `get_registered_agents()` and `get_user_preferences()` in parallel when both are needed
+- **Preference caching:** Look up previously retrieved preferences from history instead of making redundant calls
+- **Quality over quantity:** Better to remain silent than to provide unhelpful responses

--- a/hygroup/agent/system/prompt.py
+++ b/hygroup/agent/system/prompt.py
@@ -1,161 +1,6 @@
 from typing import Sequence
 
-from hygroup.agent.base import AgentRequest, Message
-from hygroup.agent.prompt import _format_input
-
-INSTRUCTIONS = """You are an intelligent agent named "system" operating in a multi-user, multi-agent group chat environment. Your primary function is to analyze messages and determine if you or your specialized subagents can provide meaningful assistance for strong information needs or action requests.
-
-## **Your Task**
-
-1. **Analyze the incoming message:** You will receive the last message from a group chat, with previous messages available in your conversation history. You are invoked with each new message except when a user invokes another agent directly (in which case you will see an update). The message will be in the following XML format:
-
-   ```xml
-   <message sender="sender_name" receiver="receiver_name">
-   message_content
-   </message>
-   ```
-
-   Messages may also contain optional `<updates>` (content from a user's direct conversation with an agent) and `<referenced-threads>` elements that provide additional context for your analysis.
-
-2. **Consult available resources (in parallel):**
-   - Use the `get_registered_agents()` tool to get a list of available subagents and their descriptions
-   - Use the `get_user_preferences(sender_name)` tool ONLY if you haven't called it for this sender before (otherwise, look up the preferences from your conversation history)
-   - Utilize any other tools you are configured with as needed
-
-3. **Process and Respond:** Analyze the current message in the context of the conversation history to determine if there is a strong information need or action request that you or your subagents can handle. Consider optional metadata elements and conversation flow when making this assessment. If yes, provide assistance. If no, remain silent.
-
-4. **Format your response:** Your response **MUST** be a single JSON object with the following structure:
-
-   **When providing assistance:**
-   ```json
-   {
-       "response": "your response to the message sender"
-   }
-   ```
-
-   **When remaining silent (default):**
-   ```json
-   {
-       "response": null
-   }
-   ```
-
-## **Core Response Principle**
-
-**Return `{"response": null}` UNLESS:**
-
-- **Receiver is "system"**: Always respond when directly addressed
-- **Receiver is NOT "system"**: Respond only if BOTH conditions are met:
-  1. The message shows a **strong information need** or **action request**
-  2. This need/request **can be addressed** by you or your subagents
-
-The default action is to remain silent. Only respond when you can provide meaningful value.
-
-## **Qualifying for Response (All Conditions Must Be Met)**
-
-Only provide a non-null response when you identify:
-
-### **1. Strong Information Need or Action Request:**
-**Qualifying examples:**
-- Explicit questions requiring substantive answers (e.g., "How do I configure X?", "What are the best practices for Y?")
-- Requests for analysis or data processing (e.g., "Analyze our Q3 sales data")
-- Requests for content creation or planning (e.g., "Create a marketing strategy")
-- Complex problem-solving requests
-- Requests for summaries, explanations, or clarifications of complex topics
-- Clear expressions of confusion that require expert assistance
-
-**NOT qualifying (return null):**
-- Simple acknowledgments (e.g., "Thanks", "OK", "Got it")
-- Casual conversation (e.g., "Hello", "How are you?")
-- Opinions or commentary not seeking response (e.g., "That's interesting", "I agree")
-- Messages between users not requesting system assistance
-- Vague statements without clear needs
-- Messages that are self-contained and don't require intervention
-
-### **2. Capability Match:**
-The identified need must be addressable by:
-- Your own capabilities, OR
-- One or more of your available subagents (based on their descriptions), OR
-- A combination of both
-
-If the need falls outside these capabilities, return null.
-
-## **Response Strategy (When Responding)**
-
-Once you've determined a response is warranted:
-
-### **1. Gather Context (In Parallel):**
-- Call `get_registered_agents()` to know available subagents
-- Check if you've previously called `get_user_preferences(sender_name)`:
-  - If NO: Call `get_user_preferences(sender_name)`
-  - If YES: Look up the preferences from your conversation history
-- Execute both calls in parallel when both are needed
-
-### **2. Determine Approach:**
-
-**Use Subagents When:**
-- The need strongly matches a subagent's specialized description
-- The task requires specific expertise described in a subagent's profile
-- Multiple specialized perspectives would enhance the response (run multiple subagents)
-
-**Respond Directly When:**
-- The need is within your general capabilities
-- No subagent specialization clearly matches better than your abilities
-- The request is for coordination itself
-
-**Use Other Tools When:**
-- Additional capabilities beyond subagents are required
-- The task requires functionalities provided by your other configured tools
-
-### **3. Run Subagent:**
-- Use `run_agent(agent_name, query)` with focused, clear queries
-- Leverage that subagents have conversation history access
-- Run multiple subagents sequentially or in parallel as needed
-
-### **4. Response Composition:**
-- Respect user preferences in formatting and style
-- Synthesize multiple inputs coherently when using multiple sources
-- Address the specific need identified in the message
-- Be concise yet complete
-
-## **Decision Examples**
-
-**Return NULL for:**
-- "Thanks for the help!" → Simple acknowledgment
-- "That's a good point" → Commentary without request
-- "Hello everyone" → Casual greeting
-- "I'll think about it" → Self-contained statement
-- "Nice weather today" → Casual conversation
-
-**Respond to:**
-- "How do I optimize our database queries?" → Strong information need, technical expertise required
-- "Can you analyze our customer churn rate?" → Action request, matches analytics capabilities
-- "I'm confused about how our authentication system works" → Clear need for explanation
-- "Create a project timeline for our new feature" → Action request, planning capability needed
-- "What are the implications of the new regulations for our business?" → Complex analysis request
-
-## **Workflow**
-
-1. Check the receiver attribute → If receiver="system", always respond (skip to step 3)
-2. For all other receiver values: Identify if there's a strong information need or action request → If no, return null
-3. Make parallel calls to:
-   - `get_registered_agents()`
-   - `get_user_preferences(sender_name)` (only if not previously called for this sender)
-4. Assess if you or subagents can address the need → If no, return null (except when receiver="system")
-5. Determine best approach (direct, subagents, or tools)
-6. Execute approach and compose response
-7. Return formatted response respecting user preferences
-
-## **Important Reminders**
-
-- **Default to null:** When uncertain, return null rather than provide marginal value
-- **Strong needs only:** Simple conversation and acknowledgments do not warrant responses
-- **Capability boundaries:** Only respond to needs you or your subagents can actually address
-- **Efficient context gathering:** Call `get_registered_agents()` and `get_user_preferences()` in parallel when both are needed
-- **Preference caching:** Look up previously retrieved preferences from history instead of making redundant calls
-- **Quality over quantity:** Better to remain silent than to provide unhelpful responses
-"""
-
+from hygroup.agent.base import AgentRequest, Message, Thread
 
 QUERY_TEMPLATE = """You are the receiver of the following message:
 
@@ -165,6 +10,90 @@ QUERY_TEMPLATE = """You are the receiver of the following message:
 
 Please analyze this message."""
 
+MESSAGE_TEMPLATE = """<message sender="{sender}" receiver="{receiver}">
+{text}{threads}
+</message>"""
 
-def format_input(request: AgentRequest, updates: Sequence[Message]) -> str:
-    return _format_input(request, updates, query_template=QUERY_TEMPLATE)
+THREADS_TEMPLATE = """
+<referenced-threads>
+{threads}
+</referenced-threads>"""
+
+UPDATES_TEMPLATE = """ You may use the following messages, enclosed in <updates> tags, as context:
+
+<updates>
+{messages}
+</updates>"""
+
+THREAD_TEMPLATE = """<thread id="{thread_id}">
+{messages}
+</thread>"""
+
+TEMPLATE = """{formatted_query}{updates}"""
+
+
+def format_input(
+    request: AgentRequest,
+    updates: Sequence[Message],
+) -> str:
+    formatted_query = format_query(request)
+    formatted_updates = ""
+
+    if updates:
+        formatted_messages = "\n".join(format_message(msg) for msg in updates)
+        formatted_updates = UPDATES_TEMPLATE.format(messages=formatted_messages)
+
+    return TEMPLATE.format(formatted_query=formatted_query, updates=formatted_updates)
+
+
+def format_query(request: AgentRequest) -> str:
+    return QUERY_TEMPLATE.format(
+        query=request.query,
+        sender=request.sender,
+        receiver=request.receiver or "",
+        threads=format_threads(request.threads),
+    )
+
+
+def format_message(message: Message) -> str:
+    return MESSAGE_TEMPLATE.format(
+        text=message.text,
+        sender=message.sender,
+        receiver=message.receiver or "",
+        threads=format_threads(message.threads),
+    )
+
+
+def format_thread(thread: Thread) -> str:
+    formatted_messages = "\n".join(format_message(message) for message in thread.messages)
+    return THREAD_TEMPLATE.format(thread_id=thread.session_id, messages=formatted_messages)
+
+
+def format_threads(threads: Sequence[Thread]) -> str:
+    if threads:
+        return THREADS_TEMPLATE.format(threads="\n".join(format_thread(thread) for thread in threads))
+    return ""
+
+
+def example():
+    threads = [
+        Thread(
+            session_id="thread1",
+            messages=[
+                Message(sender="user2", receiver="agent1", text="Can you help me?"),
+                Message(sender="agent1", receiver=None, text="Of course!"),
+            ],
+        )
+    ]
+    request = AgentRequest(query="What's the weather?", sender="user1", receiver="agent1", threads=threads)
+    updates = [
+        Message(sender="user1", receiver="agent1", text="Hello", threads=threads),
+        Message(sender="agent1", receiver="user1", text="Hi there!"),
+    ]
+
+    result = format_input(request, updates=updates)
+    print(result)
+
+
+if __name__ == "__main__":
+    example()

--- a/hygroup/agent/system/prompt.py
+++ b/hygroup/agent/system/prompt.py
@@ -1,8 +1,13 @@
-INSTRUCTIONS = """You are an intelligent agent operating in a multi-user, multi-agent group chat environment. Your primary function is to analyze messages and determine if you or your specialized subagents can provide meaningful assistance for strong information needs or action requests.
+from typing import Sequence
+
+from hygroup.agent.base import AgentRequest, Message
+from hygroup.agent.prompt import _format_input
+
+INSTRUCTIONS = """You are an intelligent agent named "system" operating in a multi-user, multi-agent group chat environment. Your primary function is to analyze messages and determine if you or your specialized subagents can provide meaningful assistance for strong information needs or action requests.
 
 ## **Your Task**
 
-1. **Analyze the incoming message:** You will receive the last message from a group chat. The message will be in the following XML format:
+1. **Analyze the incoming message:** You will receive the last message from a group chat, with previous messages available in your conversation history. You are invoked with each new message except when a user invokes another agent directly (in which case you will see an update). The message will be in the following XML format:
 
    ```xml
    <message sender="sender_name" receiver="receiver_name">
@@ -10,12 +15,14 @@ INSTRUCTIONS = """You are an intelligent agent operating in a multi-user, multi-
    </message>
    ```
 
+   Messages may also contain optional `<updates>` (content from a user's direct conversation with an agent) and `<referenced-threads>` elements that provide additional context for your analysis.
+
 2. **Consult available resources (in parallel):**
    - Use the `get_registered_agents()` tool to get a list of available subagents and their descriptions
    - Use the `get_user_preferences(sender_name)` tool ONLY if you haven't called it for this sender before (otherwise, look up the preferences from your conversation history)
    - Utilize any other tools you are configured with as needed
 
-3. **Process and Respond:** Determine if the message contains a strong information need or action request that you or your subagents can handle. If yes, provide assistance. If no, remain silent.
+3. **Process and Respond:** Analyze the current message in the context of the conversation history to determine if there is a strong information need or action request that you or your subagents can handle. Consider optional metadata elements and conversation flow when making this assessment. If yes, provide assistance. If no, remain silent.
 
 4. **Format your response:** Your response **MUST** be a single JSON object with the following structure:
 
@@ -35,10 +42,12 @@ INSTRUCTIONS = """You are an intelligent agent operating in a multi-user, multi-
 
 ## **Core Response Principle**
 
-**You MUST return `{"response": null}` unless BOTH of the following conditions are met:**
+**Return `{"response": null}` UNLESS:**
 
-1. The message shows a **strong information need** or **action request**
-2. This need/request **can be addressed** by you or your subagents
+- **Receiver is "system"**: Always respond when directly addressed
+- **Receiver is NOT "system"**: Respond only if BOTH conditions are met:
+  1. The message shows a **strong information need** or **action request**
+  2. This need/request **can be addressed** by you or your subagents
 
 The default action is to remain silent. Only respond when you can provide meaningful value.
 
@@ -127,14 +136,15 @@ Once you've determined a response is warranted:
 
 ## **Workflow**
 
-1. Identify if there's a strong information need or action request → If no, return null
-2. Make parallel calls to:
+1. Check the receiver attribute → If receiver="system", always respond (skip to step 3)
+2. For all other receiver values: Identify if there's a strong information need or action request → If no, return null
+3. Make parallel calls to:
    - `get_registered_agents()`
    - `get_user_preferences(sender_name)` (only if not previously called for this sender)
-3. Assess if you or subagents can address the need → If no, return null
-4. Determine best approach (direct, subagents, or tools)
-5. Execute approach and compose response
-6. Return formatted response respecting user preferences
+4. Assess if you or subagents can address the need → If no, return null (except when receiver="system")
+5. Determine best approach (direct, subagents, or tools)
+6. Execute approach and compose response
+7. Return formatted response respecting user preferences
 
 ## **Important Reminders**
 
@@ -145,3 +155,16 @@ Once you've determined a response is warranted:
 - **Preference caching:** Look up previously retrieved preferences from history instead of making redundant calls
 - **Quality over quantity:** Better to remain silent than to provide unhelpful responses
 """
+
+
+QUERY_TEMPLATE = """You are the receiver of the following message:
+
+<message sender="{sender}" receiver="{receiver}">
+{query}{threads}
+</message>
+
+Please analyze this message."""
+
+
+def format_input(request: AgentRequest, updates: Sequence[Message]) -> str:
+    return _format_input(request, updates, query_template=QUERY_TEMPLATE)

--- a/hygroup/scripts/server.py
+++ b/hygroup/scripts/server.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--gateway",
         type=str,
-        default="github",
+        default="terminal",
         choices=["github", "slack", "terminal"],
         help="The communication platform to use.",
     )

--- a/hygroup/scripts/server.py
+++ b/hygroup/scripts/server.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--gateway",
         type=str,
-        default="terminal",
+        default="slack",
         choices=["github", "slack", "terminal"],
         help="The communication platform to use.",
     )

--- a/hygroup/scripts/server.py
+++ b/hygroup/scripts/server.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--gateway",
         type=str,
-        default="slack",
+        default="terminal",
         choices=["github", "slack", "terminal"],
         help="The communication platform to use.",
     )

--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -34,9 +34,19 @@ class SessionAgent:
     def __init__(self, agent: Agent, session: "Session"):
         self.agent = agent
         self.session = session
+
+        # ------------------------------------------------------------
+        #  TODO: Consider making this configurable. Subagents don't
+        #        necessarily need session messages eagerly, but may
+        #        use a tool to retrieve them on demand.
+        # ------------------------------------------------------------
         self._updates: list[Message] = session.messages.copy()
-        self._queue: Queue = Queue()
-        self._task = create_task(self.worker())
+
+        self._worker_queue: Queue = Queue()
+        self._worker_task: Task | None = None
+
+    def _start_worker(self):
+        self._worker_task = create_task(self.worker())
 
     def get_state(self) -> dict[str, Any]:
         return {
@@ -49,77 +59,75 @@ class SessionAgent:
         self.agent.set_state(state["history"])
 
     async def update(self, message: Message):
-        await self._queue.put(message)
+        if self._worker_task is None:
+            self._start_worker()
+        await self._worker_queue.put(message)
 
     async def invoke(self, request: AgentRequest, secrets: dict[str, str] | None = None):
-        await self._queue.put((request, secrets, None))
+        if self._worker_task is None:
+            self._start_worker()
+        await self._worker_queue.put((request, secrets))
 
     async def run(self, request: AgentRequest, secrets: dict[str, str] | None = None) -> AgentResponse:
-        response_channel: Queue = Queue()
-        await self._queue.put((request, secrets, response_channel))
-        return await response_channel.get()
+        response: AgentResponse | None = None
+
+        # -------------------------------------
+        #  TODO: trace query
+        # -------------------------------------
+        async with self.agent.request_scope(secrets=secrets):
+            async for elem in self.agent.run(request=request, updates=self._updates):
+                match elem:
+                    case PermissionRequest():
+                        # -------------------------------------
+                        #  TODO: trace permission request
+                        # -------------------------------------
+                        await self.session.handle_permission_request(
+                            request=elem, sender=self.agent.name, receiver=request.sender
+                        )
+                    case FeedbackRequest():
+                        # -------------------------------------
+                        #  TODO: trace feedback request
+                        # -------------------------------------
+                        await self.session.handle_feedback_request(
+                            request=elem, sender=self.agent.name, receiver=request.sender
+                        )
+                    case AgentResponse():
+                        # -------------------------------------
+                        #  TODO: trace result
+                        # -------------------------------------
+                        response = replace(elem, request_id=request.id, message_id=request.message_id)
+
+        assert response, "No response from agent run"
+        return response
 
     async def worker(self):
         async with self.agent.session_scope():
             while True:
-                item = await self._queue.get()
+                item = await self._worker_queue.get()
                 match item:
                     case Message():
                         self._updates.append(item)
-                    case AgentRequest(
-                        sender=sender, id=request_id, message_id=message_id
-                    ) as request, secrets, response_channel:
+                    case AgentRequest(sender=sender, id=request_id) as request, secrets:
                         # sender name and secrets needed by run_agent tool
                         self.session._sender_info.set({"name": sender, "secrets": secrets})
 
-                        # -------------------------------------
-                        #  TODO: trace query
-                        # -------------------------------------
-                        async with self.agent.request_scope(secrets=secrets):
-                            try:
-                                async for elem in self.agent.run(request=request, updates=self._updates):
-                                    match elem:
-                                        case PermissionRequest():
-                                            # -------------------------------------
-                                            #  TODO: trace permission request
-                                            # -------------------------------------
-                                            await self.session.handle_permission_request(
-                                                request=elem, sender=self.agent.name, receiver=sender
-                                            )
-                                        case FeedbackRequest():
-                                            # -------------------------------------
-                                            #  TODO: trace feedback request
-                                            # -------------------------------------
-                                            await self.session.handle_feedback_request(
-                                                request=elem, sender=self.agent.name, receiver=sender
-                                            )
-                                        case AgentResponse():
-                                            # -------------------------------------
-                                            #  TODO: trace result
-                                            # -------------------------------------
-                                            response = replace(elem, request_id=request_id, message_id=message_id)
-                                            if response_channel is not None:
-                                                await response_channel.put(response)
-                                            else:
-                                                await self.session.handle_agent_response(
-                                                    response=response, sender=self.agent.name, receiver=sender
-                                                )
-                                # agent now has notifications part of
-                                # its history, so we can clear it
-                                self._updates = []
-                            except Exception as e:
-                                logger.exception(e)
-                                response = AgentResponse(
-                                    text=f"Execution of agent '{self.agent.name}' failed.",
-                                    request_id=request_id,
-                                )
-                                if response_channel is not None:
-                                    await response_channel.put(response)
-                                else:
-                                    await self.session.handle_system_response(
-                                        response=response,
-                                        receiver=sender,
-                                    )
+                        try:
+                            response = await self.run(request, secrets)
+                        except Exception as e:
+                            logger.exception(e)
+                            response = AgentResponse(
+                                text=f"Execution of agent '{self.agent.name}' failed.",
+                                request_id=request_id,
+                            )
+                            await self.session.handle_system_response(
+                                response=response,
+                                receiver=sender,
+                            )
+                        else:
+                            await self.session.handle_agent_response(
+                                response=response, sender=self.agent.name, receiver=sender
+                            )
+                            self._updates = []
 
 
 class Session:
@@ -339,19 +347,15 @@ class Session:
         await self._agents[agent_name].invoke(request, secrets)
 
     # -------------------------------------
-    #  Used as system agent tool
+    #  Used as agent tool
     # -------------------------------------
     async def run_agent(self, agent_name: str, query: str) -> str:
         """Run an agent identified by agent_name with the given query and return its response."""
 
-        # -------------------------------------
-        #  FIXME: run this if block atomically
-        # -------------------------------------
-        if agent_name not in self._agents:
-            try:
-                await self.load_agent(agent_name)
-            except ValueError:
-                return f'Agent "{agent_name}" not registered'
+        try:
+            agent = SessionAgent(await self.agent_registry.create_agent(agent_name), session=self)
+        except ValueError:
+            return f'Agent "{agent_name}" not registered'
 
         sender_info = self._sender_info.get()
 
@@ -360,14 +364,14 @@ class Session:
             sender=sender_info["name"],
             receiver=agent_name,
         )
-        response = await self._agents[agent_name].run(
+        response = await agent.run(
             request=request,
             secrets=sender_info["secrets"],
         )
         return response.text
 
     # -------------------------------------
-    #  Used as system agent tool
+    #  Used as agent tool
     # -------------------------------------
     async def get_user_preferences(self, username: str):
         preferences = await self.preference_store.get_preferences(username)

--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -273,25 +273,26 @@ class Session:
         threads = await self._load_referenced_threads(message_text)
 
         message = Message(
+            text=remaining_text,
             sender=message_sender,
             receiver=receiver,
-            text=remaining_text,
             threads=threads,
             id=message_id,
         )
         request = AgentRequest(
             query=message.text,
             sender=message.sender,
+            receiver=message.receiver,
             threads=message.threads,
             message_id=message.id,
         )
 
         if receiver in await self.agent_names():
             await self.update_agents(message, exclude=receiver)
-            await self.invoke_agent(request, receiver)
+            await self.invoke_agent(receiver, request)
         else:
             await self.update_agents(message, exclude="system")
-            await self.invoke_agent(request, "system")
+            await self.invoke_agent("system", request)
 
     async def update_agents(self, message: Message, exclude: str):
         # Add message to this session's message history. These are
@@ -303,16 +304,16 @@ class Session:
             if agent_name != exclude:
                 await agent.update(message)
 
-    async def invoke_agent(self, request: AgentRequest, receiver: str):
+    async def invoke_agent(self, agent_name: str, request: AgentRequest):
         # -------------------------------------
         #  FIXME: run this if block atomically
         # -------------------------------------
-        if receiver not in self._agents:
+        if agent_name not in self._agents:
             try:
-                await self.load_agent(receiver)
+                await self.load_agent(agent_name)
             except ValueError:
                 response = AgentResponse(
-                    text=f'Agent "{receiver}" not registered',
+                    text=f'Agent "{agent_name}" not registered',
                     request_id=request.id,
                 )
                 return await self.handle_system_response(
@@ -321,7 +322,7 @@ class Session:
                 )
 
         activation = AgentActivation(
-            agent_name=receiver,
+            agent_name=agent_name,
             message_id=request.message_id,
             request_id=request.id,
         )
@@ -335,13 +336,14 @@ class Session:
         secrets = self.user_registry.get_secrets(request.sender)
 
         # invoke receiver agent with request
-        await self._agents[receiver].invoke(request, secrets)
+        await self._agents[agent_name].invoke(request, secrets)
 
     # -------------------------------------
     #  Used as system agent tool
     # -------------------------------------
     async def run_agent(self, agent_name: str, query: str) -> str:
         """Run an agent identified by agent_name with the given query and return its response."""
+
         # -------------------------------------
         #  FIXME: run this if block atomically
         # -------------------------------------
@@ -352,8 +354,14 @@ class Session:
                 return f'Agent "{agent_name}" not registered'
 
         sender_info = self._sender_info.get()
+
+        request = AgentRequest(
+            query=query,
+            sender=sender_info["name"],
+            receiver=agent_name,
+        )
         response = await self._agents[agent_name].run(
-            request=AgentRequest(query=query, sender=sender_info["name"]),
+            request=request,
             secrets=sender_info["secrets"],
         )
         return response.text
@@ -381,11 +389,14 @@ class Session:
             await self.save()
 
     async def save(self):
-        state_dict = {
-            "messages": [asdict(message) for message in self._messages],
-            "agents": {name: adapter.get_state() for name, adapter in self._agents.items()},
-        }
-        await self.manager.save_session_state(self.id, state_dict)
+        try:
+            state_dict = {
+                "messages": [asdict(message) for message in self._messages],
+                "agents": {name: adapter.get_state() for name, adapter in self._agents.items()},
+            }
+            await self.manager.save_session_state(self.id, state_dict)
+        except Exception as e:
+            logger.exception(e)
 
     async def load(self):
         state_dict = await self.manager.load_session_state(self.id)

--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -200,8 +200,9 @@ class Session:
     def add_agent(self, agent: Agent):
         self._agents[agent.name] = SessionAgent(agent, self)
 
-    async def create_agent(self, name: str) -> Agent:
-        return await self.agent_registry.create_agent(name, tools=[self.get_user_preferences])
+    async def create_agent(self, name: str, extra_tools: bool = True) -> Agent:
+        tools = [self.get_user_preferences] if extra_tools else None
+        return await self.agent_registry.create_agent(name, tools=tools)
 
     async def load_agent(self, name: str):
         self.add_agent(await self.create_agent(name))
@@ -355,7 +356,7 @@ class Session:
         """Run an agent identified by agent_name with the given query and return its response."""
 
         try:
-            agent = SessionAgent(await self.create_agent(agent_name), session=self)
+            agent = SessionAgent(await self.create_agent(agent_name, False), session=self)
         except ValueError:
             return f'Agent "{agent_name}" not registered'
 

--- a/hygroup/session.py
+++ b/hygroup/session.py
@@ -74,7 +74,7 @@ class SessionAgent:
         # -------------------------------------
         #  TODO: trace query
         # -------------------------------------
-        async with self.agent.request_scope(secrets=secrets):
+        async with self.agent.mcp_servers(secrets=secrets):
             async for elem in self.agent.run(request=request, updates=self._updates):
                 match elem:
                     case PermissionRequest():
@@ -101,33 +101,32 @@ class SessionAgent:
         return response
 
     async def worker(self):
-        async with self.agent.session_scope():
-            while True:
-                item = await self._worker_queue.get()
-                match item:
-                    case Message():
-                        self._updates.append(item)
-                    case AgentRequest(sender=sender, id=request_id) as request, secrets:
-                        # sender name and secrets needed by run_agent tool
-                        self.session._sender_info.set({"name": sender, "secrets": secrets})
+        while True:
+            item = await self._worker_queue.get()
+            match item:
+                case Message():
+                    self._updates.append(item)
+                case AgentRequest(sender=sender, id=request_id) as request, secrets:
+                    # sender name and secrets needed by run_agent tool
+                    self.session._sender_info.set({"name": sender, "secrets": secrets})
 
-                        try:
-                            response = await self.run(request, secrets)
-                        except Exception as e:
-                            logger.exception(e)
-                            response = AgentResponse(
-                                text=f"Execution of agent '{self.agent.name}' failed.",
-                                request_id=request_id,
-                            )
-                            await self.session.handle_system_response(
-                                response=response,
-                                receiver=sender,
-                            )
-                        else:
-                            await self.session.handle_agent_response(
-                                response=response, sender=self.agent.name, receiver=sender
-                            )
-                            self._updates = []
+                    try:
+                        response = await self.run(request, secrets)
+                    except Exception as e:
+                        logger.exception(e)
+                        response = AgentResponse(
+                            text=f"Execution of agent '{self.agent.name}' failed.",
+                            request_id=request_id,
+                        )
+                        await self.session.handle_system_response(
+                            response=response,
+                            receiver=sender,
+                        )
+                    else:
+                        await self.session.handle_agent_response(
+                            response=response, sender=self.agent.name, receiver=sender
+                        )
+                        self._updates = []
 
 
 class Session:
@@ -201,8 +200,11 @@ class Session:
     def add_agent(self, agent: Agent):
         self._agents[agent.name] = SessionAgent(agent, self)
 
+    async def create_agent(self, name: str) -> Agent:
+        return await self.agent_registry.create_agent(name, tools=[self.get_user_preferences])
+
     async def load_agent(self, name: str):
-        self.add_agent(await self.agent_registry.create_agent(name, tools=[self.get_user_preferences]))
+        self.add_agent(await self.create_agent(name))
 
     async def agent_names(self) -> set[str]:
         names = set(self._agents.keys())
@@ -353,7 +355,7 @@ class Session:
         """Run an agent identified by agent_name with the given query and return its response."""
 
         try:
-            agent = SessionAgent(await self.agent_registry.create_agent(agent_name), session=self)
+            agent = SessionAgent(await self.create_agent(agent_name), session=self)
         except ValueError:
             return f'Agent "{agent_name}" not registered'
 

--- a/tests/integration/test_agent_registry.py
+++ b/tests/integration/test_agent_registry.py
@@ -52,13 +52,13 @@ def default_settings(model_settings, mcp_stdio_settings) -> AgentSettings:
 @pytest.fixture
 def mcp_stdio_settings() -> MCPSettings:
     """Provide MCP server settings for stdio testing."""
-    return MCPSettings(server_config={"command": "foo", "args": ["bar"]}, session_scope=True)
+    return MCPSettings(server_config={"command": "foo", "args": ["bar"]})
 
 
 @pytest.fixture
 def mcp_http_settings() -> MCPSettings:
     """Provide MCP server settings for HTTP testing."""
-    return MCPSettings(server_config={"url": "http://localhost:8000/mcp"}, session_scope=False)
+    return MCPSettings(server_config={"url": "http://localhost:8000/mcp"})
 
 
 @pytest.mark.asyncio
@@ -151,7 +151,7 @@ async def test_agent_settings_roundtrip(registry: DefaultAgentRegistry, api_key:
     if api_key:
         model_settings["api_key"] = api_key
 
-    mcp_settings = MCPSettings(server_config={"command": "test", "args": ["--debug"]}, session_scope=True)
+    mcp_settings = MCPSettings(server_config={"command": "test", "args": ["--debug"]})
 
     original_settings = AgentSettings(
         model="gpt-4",
@@ -339,8 +339,8 @@ async def test_complex_model_dict_with_all_settings(registry: DefaultAgentRegist
     }
 
     mcp_settings = [
-        MCPSettings(server_config={"command": "test-mcp", "args": ["--verbose"]}, session_scope=True),
-        MCPSettings(server_config={"url": "http://mcp.example.com"}, session_scope=False),
+        MCPSettings(server_config={"command": "test-mcp", "args": ["--verbose"]}),
+        MCPSettings(server_config={"url": "http://mcp.example.com"}),
     ]
 
     settings = AgentSettings(

--- a/tests/unit/test_session_agent.py
+++ b/tests/unit/test_session_agent.py
@@ -54,10 +54,8 @@ def mock_agent():
     """Create a mock Agent instance."""
     agent = Mock(spec=Agent)
     agent.name = "test_agent"
-    agent.session_scope.return_value.__aenter__ = AsyncMock()
-    agent.session_scope.return_value.__aexit__ = AsyncMock(return_value=None)
-    agent.request_scope.return_value.__aenter__ = AsyncMock()
-    agent.request_scope.return_value.__aexit__ = AsyncMock(return_value=None)
+    agent.mcp_servers.return_value.__aenter__ = AsyncMock(return_value=None)
+    agent.mcp_servers.return_value.__aexit__ = AsyncMock(return_value=None)
     return agent
 
 

--- a/tests/unit/test_session_agent.py
+++ b/tests/unit/test_session_agent.py
@@ -1,3 +1,4 @@
+import asyncio
 from asyncio import Event
 from contextvars import ContextVar
 from typing import Any
@@ -54,9 +55,9 @@ def mock_agent():
     agent = Mock(spec=Agent)
     agent.name = "test_agent"
     agent.session_scope.return_value.__aenter__ = AsyncMock()
-    agent.session_scope.return_value.__aexit__ = AsyncMock()
+    agent.session_scope.return_value.__aexit__ = AsyncMock(return_value=None)
     agent.request_scope.return_value.__aenter__ = AsyncMock()
-    agent.request_scope.return_value.__aexit__ = AsyncMock()
+    agent.request_scope.return_value.__aexit__ = AsyncMock(return_value=None)
     return agent
 
 
@@ -64,8 +65,12 @@ def mock_agent():
 async def session_agent(mock_agent, mock_session):
     session_agent = SessionAgent(mock_agent, mock_session)
     yield session_agent
-    session_agent._task.cancel()
-    await session_agent._task
+    if session_agent._worker_task:
+        session_agent._worker_task.cancel()
+        try:
+            await session_agent._worker_task
+        except asyncio.CancelledError:
+            pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Subagents are now fresh instances for the duration of the run_agent tool call. They are initialized with existing group messages
- Drop support for session-scope MCP servers. All MCP servers run in request scope.
- Emission of permission and feedback requests now based on custom WrapperToolset
- Experimental changes to system agent instructions and input formatting (preliminary)