### PR TITLE
Simplify Slack message truncation to clip at 2990 chars

### DIFF
--- a/hygroup/gateway/slack/responses.py
+++ b/hygroup/gateway/slack/responses.py
@@ -79,6 +79,11 @@ class SlackResponseHandler:
         receiver_resolved_formatted = f"<@{receiver_resolved}>"
 
         text = f"{receiver_resolved_formatted} {response.text}"
+        
+        # Truncate message if it exceeds Slack's character limit
+        if len(text) > 2990:
+            text = text[:2990] + "..."
+        
         blocks = [
             {
                 "type": "section",


### PR DESCRIPTION
Simplifies Slack message handling to use basic truncation instead of complex file upload solution.

## Changes
- Add simple truncation logic that clips at 2990 characters
- Append '...' when truncation occurs
- Keeps total length under Slack's 3000 character limit
- Removes complexity of previous solution

Closes #78

Generated with [Claude Code](https://claude.ai/code)