### PR TITLE
Update group-genie to 0.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ __pycache__
 .claude/
 .secrets/
 extra
+demo/scripts
 sandbox*
 site

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "markdown-to-mrkdwn>=0.2.0,<0.3",
     "composio-client>=1.7.0",
     "pillow>=11.3.0,<12",
-    "group-genie>=0.0.2,<0.1",
+    "group-genie>=0.0.3,<0.1",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1165,28 +1165,28 @@ wheels = [
 
 [[package]]
 name = "group-genie"
-version = "0.0.2"
+version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
     { name = "group-sense" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/74/c20d5f3c62362599a490689db5863e814a4e95af599cdc28a9af3b1ba8f7/group_genie-0.0.2.tar.gz", hash = "sha256:542e7646f05f967726d7f24459a4c699abb8ca0f952e06ee20bbd406e16fcf9b", size = 31560, upload-time = "2026-01-06T15:45:29.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/83/c467ff26dc19316108fb42292cc4473d0b0f4e9658201d86417a94288e82/group_genie-0.0.3.tar.gz", hash = "sha256:eee0ac48655f377a6b68f14624a463f577f4a4be86539ac8b484e20f06fbe0e9", size = 31976, upload-time = "2026-02-05T12:34:46.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/30/2848a02d75b0812d39775361caa9d2211525fb1b36939c77ce5ca9d7a3ef/group_genie-0.0.2-py3-none-any.whl", hash = "sha256:9f4189bf18af7e7debae88b9ac08827dc7b3c9ef78e7010d5bd5692fa8af3e0e", size = 44432, upload-time = "2026-01-06T15:45:28.449Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2d/172f23e507cf6eabd782007ac205d752c5ccdfedf58cffdebd512babecdd/group_genie-0.0.3-py3-none-any.whl", hash = "sha256:7230a52769a6f0b980dd1488de0c7bb5ff343754e294a40236d3de75845e73bf", size = 44845, upload-time = "2026-02-05T12:34:45.634Z" },
 ]
 
 [[package]]
 name = "group-sense"
-version = "0.0.4"
+version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-genai" },
     { name = "pydantic-ai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/de/a12c6e8ea4e88af8a3acee78925e51bd59c20206a89f3621d4f3938f1a46/group_sense-0.0.4.tar.gz", hash = "sha256:382bf544da9a09728f1c894e9499261b36485022ab7a9aa602eab081a084d787", size = 12160, upload-time = "2026-01-06T15:09:45.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/00/cd7915a4e1acdde2bd841fd5f2fc12a520bed9ff1f29af26954daa352d30/group_sense-0.0.5.tar.gz", hash = "sha256:cc65749bd725a3efb251244706d6b667f3b09ec65bb13b409b8c002c7fbca9b2", size = 12228, upload-time = "2026-02-05T12:12:01.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/dc/ad51f8c24e3eb1431208329e0cce921b2d845a2a14985533f07b3c188c83/group_sense-0.0.4-py3-none-any.whl", hash = "sha256:dc17f5f1762864e3455cb47e3626b857c910e361ad68449ae66dc30e293c0957", size = 14852, upload-time = "2026-01-06T15:09:44.554Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/36/2d8e012bc40e1245d9adbe6fb79451cd283c3f16ef7eb70ec7e0bc170e35/group_sense-0.0.5-py3-none-any.whl", hash = "sha256:20a98891f2d14452eb1fdc118c86aaa260405e0e102ee786839321b9ed0fa99e", size = 14936, upload-time = "2026-02-05T12:12:00.055Z" },
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ requires-dist = [
     { name = "fastapi", extras = ["all"], specifier = ">=0.115.12,<0.116" },
     { name = "gitingest", specifier = ">=0.1.4,<0.2" },
     { name = "google-genai", specifier = ">=1.21.1,<2" },
-    { name = "group-genie", specifier = ">=0.0.2,<0.1" },
+    { name = "group-genie", specifier = ">=0.0.3,<0.1" },
     { name = "markdown-to-mrkdwn", specifier = ">=0.2.0,<0.3" },
     { name = "mcp", specifier = ">=1.13.0,<2" },
     { name = "pillow", specifier = ">=11.3.0,<12" },


### PR DESCRIPTION
## Summary
- Update group-genie dependency from 0.0.2 to 0.0.3
- Add demo/scripts to .gitignore

## Test plan
- [x] All 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)